### PR TITLE
remove -h and -v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Based on [Keep a Changelog].
 
 ## Versions
 
+### 0.5.0
+
+#### Changed
+
+* `@ShowHelp` decorator no longer sets the "-h" option, but only "--help".
+* `@ShowVersion` decorator no longer sets the "-v" option, but only "--version".
+
 ### 0.4.1
 
 #### Added

--- a/spec/book/defining_help_options.spec.ts
+++ b/spec/book/defining_help_options.spec.ts
@@ -18,7 +18,7 @@ it(__filename, async () => {
     await shouldThrow(
       Exit,
       async () => {
-        await run(Command, ['-h'], { throwOnExit: true });
+        await run(Command, ['--help'], { throwOnExit: true });
       },
       (exit: Exit) => {
         expect(exit.status).toEqual(0);
@@ -29,5 +29,5 @@ it(__filename, async () => {
   expect(captured).toEqual(`command [OPTIONS] [ARG]
 
 Options:
-  --help, -h  Show this help.\n`);
+  --help  Show this help.\n`);
 });

--- a/spec/book/defining_version_options.spec.ts
+++ b/spec/book/defining_version_options.spec.ts
@@ -16,7 +16,7 @@ it(__filename, async () => {
     await shouldThrow(
       Exit,
       async () => {
-        await run(Command, ['-v'], { throwOnExit: true });
+        await run(Command, ['--version'], { throwOnExit: true });
       },
       (exit: Exit) => {
         expect(exit.status).toEqual(0);

--- a/src/decorators/ShowHelp.ts
+++ b/src/decorators/ShowHelp.ts
@@ -13,7 +13,7 @@ export function ShowHelp(options?: ShowHelpOptions) {
   return <T extends ClassDecoratorTargetType>(constructor: T) => {
     // tslint:disable-next-line:no-parameter-reassignment
     options = options ? options : {};
-    const name: string[] = options.name === undefined ? ['-h', '--help'] : options.name;
+    const name: string[] = options.name === undefined ? ['--help'] : options.name;
     const desc: string = options.desc === undefined ? 'Show this help.' : options.desc;
     Option({ name, desc, type: Boolean })({ constructor }, '@help');
     Handler(() => {

--- a/src/decorators/ShowVersion.ts
+++ b/src/decorators/ShowVersion.ts
@@ -12,7 +12,7 @@ export function ShowVersion(version: string, options?: ShowVersionOptions) {
   return <T extends ClassDecoratorTargetType>(constructor: T) => {
     // tslint:disable-next-line:no-parameter-reassignment
     options = options ? options : {};
-    const name: string[] = options.name === undefined ? ['-v', '--version'] : options.name;
+    const name: string[] = options.name === undefined ? ['--version'] : options.name;
     const desc: string = options.desc === undefined ? 'Show version.' : options.desc;
     Option({ name, desc, type: Boolean })({ constructor }, '@version');
     Handler(() => {


### PR DESCRIPTION
@ShowHelp and @ShowVersion decorators no longer set their single letter options, -h and -v.